### PR TITLE
Fix compass click and spawn witches in all worlds

### DIFF
--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
@@ -4,6 +4,7 @@ import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -22,11 +23,18 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
 
     @EventHandler
     public void onInteract(PlayerInteractEvent event) {
-        if (event.getItem() != null && event.getItem().getType() == Material.COMPASS) {
-            if (event.getPlayer() != null) {
-                event.setCancelled(true);
-                gameSelection.open(event.getPlayer());
-            }
+        if (event.getItem() == null || event.getItem().getType() != Material.COMPASS) {
+            return;
+        }
+
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+
+        if (event.getPlayer() != null) {
+            event.setCancelled(true);
+            gameSelection.open(event.getPlayer());
         }
     }
 

--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/WitchShop.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/WitchShop.java
@@ -15,12 +15,15 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -39,23 +42,28 @@ public class WitchShop implements Listener {
     private static final InventoryHolder HOLDER = new ShopHolder();
 
     private final JavaPlugin plugin;
-    private UUID witchId;
+    private final Set<UUID> witchIds = new HashSet<>();
     private Inventory shopInv;
 
     public WitchShop(JavaPlugin plugin) {
         this.plugin = plugin;
-        spawnWitch();
+        spawnWitches();
         setupInventory();
     }
 
-    private void spawnWitch() {
-        World world = Bukkit.getServer().getWorlds().get(0);
+    private void spawnWitches() {
+        for (World world : Bukkit.getServer().getWorlds()) {
+            spawnWitch(world);
+        }
+    }
+
+    private void spawnWitch(World world) {
         Location loc = new Location(world, 6, 11, 44);
         Witch witch = (Witch) world.spawnEntity(loc, EntityType.WITCH);
         witch.setAI(false);
         witch.setCustomName(ChatColor.DARK_PURPLE + "Shopkeeper");
         witch.setCustomNameVisible(true);
-        this.witchId = witch.getUniqueId();
+        witchIds.add(witch.getUniqueId());
     }
 
     private void setupInventory() {
@@ -78,7 +86,7 @@ public class WitchShop implements Listener {
     @EventHandler
     public void onInteract(PlayerInteractEntityEvent event) {
         Entity entity = event.getRightClicked();
-        if (!entity.getUniqueId().equals(witchId)) {
+        if (!witchIds.contains(entity.getUniqueId())) {
             return;
         }
         Player player = event.getPlayer();
@@ -112,15 +120,20 @@ public class WitchShop implements Listener {
     // Prevent natural despawn or damage to the witch
     @EventHandler
     public void onDamage(EntityDamageEvent event) {
-        if (event.getEntity().getUniqueId().equals(witchId)) {
+        if (witchIds.contains(event.getEntity().getUniqueId())) {
             event.setCancelled(true);
         }
     }
 
     @EventHandler
     public void onSpawn(CreatureSpawnEvent event) {
-        if (event.getEntity().getUniqueId().equals(witchId)) {
+        if (witchIds.contains(event.getEntity().getUniqueId())) {
             event.setCancelled(false);
         }
+    }
+
+    @EventHandler
+    public void onWorldLoad(WorldLoadEvent event) {
+        spawnWitch(event.getWorld());
     }
 }


### PR DESCRIPTION
## Summary
- spawn a shop witch in every world and keep track of them
- add world load listener so new worlds also get a shop witch
- open the game selection menu only on right-click with the compass

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446d236840832791a11cef48ef2cd9