### PR TITLE
Fix witch spawn and disable mob spawning

### DIFF
--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
@@ -1,6 +1,8 @@
 package me.Kulmodroid.serverPlugin.serverPlugin;
 
 import org.bukkit.Material;
+import org.bukkit.GameRule;
+import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -43,6 +45,10 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
         duelManager = new DuelManager(this);
         gameSelection = new GameSelection(duelManager);
         witchShop = new WitchShop(this);
+
+        for (World world : getServer().getWorlds()) {
+            world.setGameRule(GameRule.DO_MOB_SPAWNING, false);
+        }
 
         getServer().getPluginManager().registerEvents(this, this);
         getServer().getPluginManager().registerEvents(gameSelection, this);

--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/WitchShop.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/WitchShop.java
@@ -58,11 +58,17 @@ public class WitchShop implements Listener {
     }
 
     private void spawnWitch(World world) {
-        Location loc = new Location(world, 6, 11, 44);
+        Location loc = new Location(world, -50, 11, 25);
         Witch witch = (Witch) world.spawnEntity(loc, EntityType.WITCH);
         witch.setAI(false);
         witch.setCustomName(ChatColor.DARK_PURPLE + "Shopkeeper");
         witch.setCustomNameVisible(true);
+        witch.setRemoveWhenFarAway(false);
+        try {
+            witch.setPersistent(true);
+        } catch (NoSuchMethodError ignore) {
+            // method not available on older API versions
+        }
         witchIds.add(witch.getUniqueId());
     }
 
@@ -128,7 +134,10 @@ public class WitchShop implements Listener {
     @EventHandler
     public void onSpawn(CreatureSpawnEvent event) {
         if (witchIds.contains(event.getEntity().getUniqueId())) {
-            event.setCancelled(false);
+            return;
+        }
+        if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.CUSTOM) {
+            event.setCancelled(true);
         }
     }
 


### PR DESCRIPTION
## Summary
- keep the shop witch alive on peaceful and move it to `-50 11 25`
- cancel mob spawns that aren't plugin controlled
- disable mob spawning via gamerule for all worlds

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68446f6d5e348327ae41a40681b56d35