### PR TITLE
Add lightning staff item

### DIFF
--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
@@ -1,13 +1,19 @@
 package me.Kulmodroid.serverPlugin.serverPlugin;
 
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.Vector;
 
 public final class ServerPlugin extends JavaPlugin implements Listener {
 
@@ -15,15 +21,26 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
     private GameSelection gameSelection;
     private WitchShop witchShop;
 
+    private static final ItemStack LIGHTNING_STAFF;
+
+    static {
+        LIGHTNING_STAFF = new ItemStack(Material.BLAZE_ROD);
+        ItemMeta meta = LIGHTNING_STAFF.getItemMeta();
+        meta.setDisplayName(ChatColor.GOLD + "Lightning Staff");
+        LIGHTNING_STAFF.setItemMeta(meta);
+    }
+
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         event.getPlayer().sendMessage("Welcome to our server, " + event.getPlayer().getName() + ", your current ping is: " + event.getPlayer().getPing());
         event.getPlayer().getInventory().addItem(new ItemStack(Material.COMPASS));
+        event.getPlayer().getInventory().addItem(LIGHTNING_STAFF.clone());
     }
 
     @EventHandler
     public void onInteract(PlayerInteractEvent event) {
-        if (event.getItem() == null || event.getItem().getType() != Material.COMPASS) {
+        ItemStack item = event.getItem();
+        if (item == null) {
             return;
         }
 
@@ -32,9 +49,31 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
             return;
         }
 
-        if (event.getPlayer() != null) {
+        Player player = event.getPlayer();
+        if (item.getType() == Material.COMPASS) {
             event.setCancelled(true);
-            gameSelection.open(event.getPlayer());
+            gameSelection.open(player);
+        } else if (isLightningStaff(item)) {
+            event.setCancelled(true);
+            strikeLightningLine(player);
+        }
+    }
+
+    private boolean isLightningStaff(ItemStack item) {
+        if (item.getType() != Material.BLAZE_ROD) {
+            return false;
+        }
+        ItemMeta meta = item.getItemMeta();
+        return meta != null && meta.hasDisplayName() && meta.getDisplayName().equals(LIGHTNING_STAFF.getItemMeta().getDisplayName());
+    }
+
+    private void strikeLightningLine(Player player) {
+        Location start = player.getLocation();
+        Vector direction = start.getDirection().normalize();
+        World world = player.getWorld();
+        for (int i = 1; i <= 20; i++) {
+            Location loc = start.clone().add(direction.clone().multiply(i));
+            world.strikeLightning(loc);
         }
     }
 


### PR DESCRIPTION
## Summary
- add a Lightning Staff item given on player join
- right clicking the staff calls a line of lightning bolts 20 blocks ahead

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844701dbd0c8327bfb22390a6b7352a