### PR TITLE
Add Breeze Rod item and refactor special items

### DIFF
--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
@@ -1,26 +1,20 @@
 package me.Kulmodroid.serverPlugin.serverPlugin;
 
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
+import org.bukkit.GameRule;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.GameRule;
-import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Pig;
-import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.Action;
-import org.bukkit.event.entity.EntityShootBowEvent;
-import org.bukkit.event.entity.ProjectileHitEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.block.Action;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.util.Vector;
+
+import me.Kulmodroid.serverPlugin.serverPlugin.items.BreezeRod;
+import me.Kulmodroid.serverPlugin.serverPlugin.items.LightningStaff;
+import me.Kulmodroid.serverPlugin.serverPlugin.items.PigBow;
 
 public final class ServerPlugin extends JavaPlugin implements Listener {
 
@@ -28,118 +22,43 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
     private GameSelection gameSelection;
     private WitchShop witchShop;
 
-    private static final ItemStack LIGHTNING_STAFF;
-    private static final ItemStack PIG_BOW;
-    private static final String PIG_ARROW_KEY = "pig-bow-arrow";
-
-    static {
-        LIGHTNING_STAFF = new ItemStack(Material.BLAZE_ROD);
-        ItemMeta meta = LIGHTNING_STAFF.getItemMeta();
-        meta.setDisplayName(ChatColor.GOLD + "Lightning Staff");
-        LIGHTNING_STAFF.setItemMeta(meta);
-
-        PIG_BOW = new ItemStack(Material.BOW);
-        ItemMeta bowMeta = PIG_BOW.getItemMeta();
-        bowMeta.setDisplayName(ChatColor.LIGHT_PURPLE + "Pig Bow");
-        PIG_BOW.setItemMeta(bowMeta);
-    }
+    private LightningStaff lightningStaff;
+    private PigBow pigBow;
+    private BreezeRod breezeRod;
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
-        event.getPlayer().sendMessage("Welcome to our server, " + event.getPlayer().getName() + ", your current ping is: " + event.getPlayer().getPing());
-        event.getPlayer().getInventory().addItem(new ItemStack(Material.COMPASS));
-        event.getPlayer().getInventory().addItem(LIGHTNING_STAFF.clone());
-        event.getPlayer().getInventory().addItem(PIG_BOW.clone());
-        event.getPlayer().getInventory().addItem(new ItemStack(Material.ARROW, 64));
+        Player player = event.getPlayer();
+        player.sendMessage("Welcome to our server, " + player.getName() + ", your current ping is: " + player.getPing());
+        player.getInventory().addItem(new ItemStack(Material.COMPASS));
+        player.getInventory().addItem(lightningStaff.getItem());
+        player.getInventory().addItem(pigBow.getItem());
+        player.getInventory().addItem(breezeRod.getItem());
+        player.getInventory().addItem(new ItemStack(Material.ARROW, 64));
     }
 
     @EventHandler
     public void onInteract(PlayerInteractEvent event) {
-        ItemStack item = event.getItem();
-        if (item == null) {
+        if (event.getItem() == null || event.getItem().getType() != Material.COMPASS) {
             return;
         }
-
         Action action = event.getAction();
         if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
             return;
         }
-
-        Player player = event.getPlayer();
-        if (item.getType() == Material.COMPASS) {
-            event.setCancelled(true);
-            gameSelection.open(player);
-        } else if (isLightningStaff(item)) {
-            event.setCancelled(true);
-            strikeLightningLine(player);
-        } else if (isPigBow(item)) {
-            // Right click with pig bow should not trigger any special action
-        }
+        event.setCancelled(true);
+        gameSelection.open(event.getPlayer());
     }
 
-    @EventHandler
-    public void onShoot(EntityShootBowEvent event) {
-        if (!(event.getEntity() instanceof Player player)) {
-            return;
-        }
-        ItemStack bow = event.getBow();
-        if (bow != null && isPigBow(bow)) {
-            event.getProjectile().setMetadata(PIG_ARROW_KEY,
-                    new FixedMetadataValue(this, true));
-        }
-    }
-
-    @EventHandler
-    public void onArrowHit(ProjectileHitEvent event) {
-        if (!(event.getEntity() instanceof Arrow arrow)) {
-            return;
-        }
-        if (!arrow.hasMetadata(PIG_ARROW_KEY)) {
-            return;
-        }
-
-        arrow.removeMetadata(PIG_ARROW_KEY, this);
-        Location loc = arrow.getLocation();
-        World world = arrow.getWorld();
-        arrow.remove();
-        for (int i = 0; i < 5; i++) {
-            Pig pig = (Pig) world.spawnEntity(loc, EntityType.PIG);
-            Vector velocity = new Vector(Math.random() - 0.5, 0.5, Math.random() - 0.5);
-            pig.setVelocity(velocity);
-        }
-    }
-
-    private boolean isLightningStaff(ItemStack item) {
-        if (item.getType() != Material.BLAZE_ROD) {
-            return false;
-        }
-        ItemMeta meta = item.getItemMeta();
-        return meta != null && meta.hasDisplayName() && meta.getDisplayName().equals(LIGHTNING_STAFF.getItemMeta().getDisplayName());
-    }
-
-    private boolean isPigBow(ItemStack item) {
-        if (item.getType() != Material.BOW) {
-            return false;
-        }
-        ItemMeta meta = item.getItemMeta();
-        return meta != null && meta.hasDisplayName() && meta.getDisplayName().equals(PIG_BOW.getItemMeta().getDisplayName());
-    }
-
-    private void strikeLightningLine(Player player) {
-        Location start = player.getLocation();
-        Vector direction = start.getDirection().normalize();
-        World world = player.getWorld();
-        for (int i = 1; i <= 20; i++) {
-            Location loc = start.clone().add(direction.clone().multiply(i));
-            world.strikeLightning(loc);
-        }
-    }
 
     @Override
     public void onEnable() {
         duelManager = new DuelManager(this);
         gameSelection = new GameSelection(duelManager);
         witchShop = new WitchShop(this);
+        lightningStaff = new LightningStaff(this);
+        pigBow = new PigBow(this);
+        breezeRod = new BreezeRod();
 
         for (World world : getServer().getWorlds()) {
             world.setGameRule(GameRule.DO_MOB_SPAWNING, false);
@@ -149,6 +68,9 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(gameSelection, this);
         getServer().getPluginManager().registerEvents(duelManager, this);
         getServer().getPluginManager().registerEvents(witchShop, this);
+        getServer().getPluginManager().registerEvents(lightningStaff, this);
+        getServer().getPluginManager().registerEvents(pigBow, this);
+        getServer().getPluginManager().registerEvents(breezeRod, this);
 
         getCommand("gameselection").setExecutor(new GameSelectionCommand(gameSelection));
         getCommand("ping").setExecutor(new PingCommand());

--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/items/BreezeRod.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/items/BreezeRod.java
@@ -1,0 +1,70 @@
+package me.Kulmodroid.serverPlugin.serverPlugin.items;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Item that summons a circle of vexes when used.
+ */
+public class BreezeRod implements Listener {
+
+    /** Display item for the rod. */
+    private static final ItemStack ITEM;
+
+    static {
+        ITEM = new ItemStack(Material.BREEZE_ROD);
+        ItemMeta meta = ITEM.getItemMeta();
+        meta.setDisplayName(ChatColor.AQUA + "Breeze Rod");
+        ITEM.setItemMeta(meta);
+    }
+
+    /** Returns a copy of the Breeze Rod item. */
+    public ItemStack getItem() {
+        return ITEM.clone();
+    }
+
+    private boolean isBreezeRod(ItemStack stack) {
+        if (stack == null || stack.getType() != Material.BREEZE_ROD) {
+            return false;
+        }
+        ItemMeta meta = stack.getItemMeta();
+        return meta != null && meta.hasDisplayName()
+                && meta.getDisplayName().equals(ITEM.getItemMeta().getDisplayName());
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        if (!isBreezeRod(event.getItem())) {
+            return;
+        }
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        event.setCancelled(true);
+        spawnVexes(event.getPlayer());
+    }
+
+    private void spawnVexes(Player player) {
+        Location center = player.getLocation();
+        World world = player.getWorld();
+        double radius = 5.0;
+        for (int i = 0; i < 10; i++) {
+            double angle = 2 * Math.PI * i / 10;
+            double x = center.getX() + radius * Math.cos(angle);
+            double z = center.getZ() + radius * Math.sin(angle);
+            Location loc = new Location(world, x, center.getY(), z);
+            world.spawnEntity(loc, EntityType.VEX);
+        }
+    }
+}

--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/items/LightningStaff.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/items/LightningStaff.java
@@ -1,0 +1,74 @@
+package me.Kulmodroid.serverPlugin.serverPlugin.items;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.Vector;
+
+/**
+ * Lightning staff item that strikes lightning in a line when used.
+ */
+public class LightningStaff implements Listener {
+
+    /** The display item for this staff. */
+    private static final ItemStack ITEM;
+
+    static {
+        ITEM = new ItemStack(Material.BLAZE_ROD);
+        ItemMeta meta = ITEM.getItemMeta();
+        meta.setDisplayName(ChatColor.GOLD + "Lightning Staff");
+        ITEM.setItemMeta(meta);
+    }
+
+    private final JavaPlugin plugin;
+
+    public LightningStaff(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /** Returns a copy of the lightning staff item. */
+    public ItemStack getItem() {
+        return ITEM.clone();
+    }
+
+    private boolean isStaff(ItemStack stack) {
+        if (stack == null || stack.getType() != Material.BLAZE_ROD) {
+            return false;
+        }
+        ItemMeta meta = stack.getItemMeta();
+        return meta != null && meta.hasDisplayName()
+                && meta.getDisplayName().equals(ITEM.getItemMeta().getDisplayName());
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        if (!isStaff(event.getItem())) {
+            return;
+        }
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        event.setCancelled(true);
+        strikeLightningLine(event.getPlayer());
+    }
+
+    private void strikeLightningLine(Player player) {
+        Location start = player.getLocation();
+        Vector direction = start.getDirection().normalize();
+        World world = player.getWorld();
+        for (int i = 1; i <= 20; i++) {
+            Location loc = start.clone().add(direction.clone().multiply(i));
+            world.strikeLightning(loc);
+        }
+    }
+}

--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/items/PigBow.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/items/PigBow.java
@@ -1,0 +1,88 @@
+package me.Kulmodroid.serverPlugin.serverPlugin.items;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Pig;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.Vector;
+
+/**
+ * Bow that spawns pigs where arrows land.
+ */
+public class PigBow implements Listener {
+
+    /** Metadata key to tag arrows shot from this bow. */
+    private static final String ARROW_KEY = "pig-bow-arrow";
+
+    /** Display item for the bow. */
+    private static final ItemStack ITEM;
+
+    static {
+        ITEM = new ItemStack(Material.BOW);
+        ItemMeta meta = ITEM.getItemMeta();
+        meta.setDisplayName(ChatColor.LIGHT_PURPLE + "Pig Bow");
+        ITEM.setItemMeta(meta);
+    }
+
+    private final JavaPlugin plugin;
+
+    public PigBow(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /** Returns a copy of the bow item. */
+    public ItemStack getItem() {
+        return ITEM.clone();
+    }
+
+    private boolean isPigBow(ItemStack stack) {
+        if (stack == null || stack.getType() != Material.BOW) {
+            return false;
+        }
+        ItemMeta meta = stack.getItemMeta();
+        return meta != null && meta.hasDisplayName()
+                && meta.getDisplayName().equals(ITEM.getItemMeta().getDisplayName());
+    }
+
+    @EventHandler
+    public void onShoot(EntityShootBowEvent event) {
+        if (!(event.getEntity() instanceof Player)) {
+            return;
+        }
+        if (isPigBow(event.getBow())) {
+            event.getProjectile().setMetadata(ARROW_KEY, new FixedMetadataValue(plugin, true));
+        }
+    }
+
+    @EventHandler
+    public void onArrowHit(ProjectileHitEvent event) {
+        if (!(event.getEntity() instanceof Arrow arrow)) {
+            return;
+        }
+        if (!arrow.hasMetadata(ARROW_KEY)) {
+            return;
+        }
+
+        arrow.removeMetadata(ARROW_KEY, plugin);
+        Location loc = arrow.getLocation();
+        World world = arrow.getWorld();
+        arrow.remove();
+        for (int i = 0; i < 5; i++) {
+            Pig pig = (Pig) world.spawnEntity(loc, EntityType.PIG);
+            Vector velocity = new Vector(Math.random() - 0.5, 0.5, Math.random() - 0.5);
+            pig.setVelocity(velocity);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `BreezeRod` item that spawns Vexes around the player
- move Lightning Staff and Pig Bow logic into their own listener classes
- register the new item listeners in the main plugin

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447db298fc8327b5900f2531a75298