### PR TITLE
Adjust Breeze Rod vex behavior

### DIFF
--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
@@ -58,7 +58,7 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
         witchShop = new WitchShop(this);
         lightningStaff = new LightningStaff(this);
         pigBow = new PigBow(this);
-        breezeRod = new BreezeRod();
+        breezeRod = new BreezeRod(this);
 
         for (World world : getServer().getWorlds()) {
             world.setGameRule(GameRule.DO_MOB_SPAWNING, false);


### PR DESCRIPTION
## Summary
- keep breeze rod vexes from attacking the summoner
- update `ServerPlugin` to pass the plugin instance

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447fc0e2f083278697c25afa84e455