### PR TITLE
Add block protection on server start

### DIFF
--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/BlockProtection.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/BlockProtection.java
@@ -1,0 +1,24 @@
+package me.Kulmodroid.serverPlugin.serverPlugin;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+/**
+ * Prevents normal players from breaking existing world blocks.
+ */
+public class BlockProtection implements Listener {
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        if (player.isOp() || player.hasPermission("serverPlugin.admin")) {
+            return;
+        }
+        if (event.getBlock().getType() != Material.AIR) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
@@ -17,6 +17,8 @@ import me.Kulmodroid.serverPlugin.serverPlugin.items.LightningStaff;
 import me.Kulmodroid.serverPlugin.serverPlugin.items.PigBow;
 import me.Kulmodroid.serverPlugin.serverPlugin.items.JumpBow;
 
+import me.Kulmodroid.serverPlugin.serverPlugin.BlockProtection;
+
 public final class ServerPlugin extends JavaPlugin implements Listener {
 
     private DuelManager duelManager;
@@ -28,6 +30,7 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
     private PigBow pigBow;
     private BreezeRod breezeRod;
     private JumpBow jumpBow;
+    private BlockProtection blockProtection;
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
@@ -65,6 +68,7 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
         pigBow = new PigBow(this);
         breezeRod = new BreezeRod(this);
         jumpBow = new JumpBow(this);
+        blockProtection = new BlockProtection();
 
         for (World world : getServer().getWorlds()) {
             world.setGameRule(GameRule.DO_MOB_SPAWNING, false);
@@ -79,6 +83,7 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(pigBow, this);
         getServer().getPluginManager().registerEvents(breezeRod, this);
         getServer().getPluginManager().registerEvents(jumpBow, this);
+        getServer().getPluginManager().registerEvents(blockProtection, this);
 
         getCommand("gameselection").setExecutor(new GameSelectionCommand(gameSelection));
         getCommand("ping").setExecutor(new PingCommand());


### PR DESCRIPTION
## Summary
- create BlockProtection listener to cancel block breaks for non-admins
- register BlockProtection in the main plugin

## Testing
- `mvn package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486671119c8327acca2895a610a094