### PR TITLE
Add zone limiter to restrict movement

### DIFF
--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ServerPlugin.java
@@ -3,6 +3,7 @@ package me.Kulmodroid.serverPlugin.serverPlugin;
 import org.bukkit.GameRule;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.WorldBorder;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -28,6 +29,7 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
     private PigBow pigBow;
     private BreezeRod breezeRod;
     private JumpBow jumpBow;
+    private ZoneLimiter zoneLimiter;
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
@@ -68,7 +70,14 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
 
         for (World world : getServer().getWorlds()) {
             world.setGameRule(GameRule.DO_MOB_SPAWNING, false);
+
+            WorldBorder border = world.getWorldBorder();
+            border.setWarningDistance(0);
+            border.setWarningTime(0);
         }
+
+        zoneLimiter = new ZoneLimiter(this, getServer().getWorlds().get(0),
+                -100, 0, -100, 100, 256, 100);
 
         getServer().getPluginManager().registerEvents(this, this);
         getServer().getPluginManager().registerEvents(gameSelection, this);
@@ -79,6 +88,7 @@ public final class ServerPlugin extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(pigBow, this);
         getServer().getPluginManager().registerEvents(breezeRod, this);
         getServer().getPluginManager().registerEvents(jumpBow, this);
+        getServer().getPluginManager().registerEvents(zoneLimiter, this);
 
         getCommand("gameselection").setExecutor(new GameSelectionCommand(gameSelection));
         getCommand("ping").setExecutor(new PingCommand());

--- a/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ZoneLimiter.java
+++ b/src/main/java/me/Kulmodroid/serverPlugin/serverPlugin/ZoneLimiter.java
@@ -1,0 +1,60 @@
+package me.Kulmodroid.serverPlugin.serverPlugin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.Vector;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Restricts players to a rectangular zone and teleports them back if they exit.
+ */
+public class ZoneLimiter implements Listener {
+
+    private final JavaPlugin plugin;
+    private final World world;
+    private final Vector min;
+    private final Vector max;
+    private final Map<Player, Location> lastValid = new HashMap<>();
+
+    public ZoneLimiter(JavaPlugin plugin, World world,
+                       double x1, double y1, double z1,
+                       double x2, double y2, double z2) {
+        this.plugin = plugin;
+        this.world = world;
+        this.min = new Vector(Math.min(x1, x2), Math.min(y1, y2), Math.min(z1, z2));
+        this.max = new Vector(Math.max(x1, x2), Math.max(y1, y2), Math.max(z1, z2));
+    }
+
+    private boolean isInside(Location loc) {
+        return loc.getX() >= min.getX() && loc.getX() <= max.getX()
+                && loc.getY() >= min.getY() && loc.getY() <= max.getY()
+                && loc.getZ() >= min.getZ() && loc.getZ() <= max.getZ();
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        if (!player.getWorld().equals(world)) {
+            return;
+        }
+        Location to = event.getTo();
+        if (to == null) {
+            return;
+        }
+        if (isInside(to)) {
+            lastValid.put(player, to);
+            return;
+        }
+        Location back = lastValid.getOrDefault(player, event.getFrom());
+        event.setCancelled(true);
+        Bukkit.getScheduler().runTask(plugin, () -> player.teleport(back));
+    }
+}


### PR DESCRIPTION
## Summary
- add `ZoneLimiter` listener to keep players inside a rectangular area
- hide worldborder warnings and enable the zone limiter in `ServerPlugin`

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684865f51b5c8327a9bb42548c2518ba